### PR TITLE
Allow overriding of static url's

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -504,6 +504,17 @@ defmodule Phoenix.Endpoint do
           &Phoenix.Endpoint.Supervisor.static_url/1)
       end
 
+      def static_url(path) do
+        (static_url() <> static_path(path))
+        |> static_url_override(static_path(path))
+      end
+
+      def static_url_override(url, _path) do
+        url
+      end
+
+      defoverridable static_url_override: 2
+
       @doc """
       Generates the endpoint base URL but as a `URI` struct.
 

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -247,7 +247,7 @@ defmodule Phoenix.Router.Helpers do
       end
 
       def static_url(endpoint, path) when is_atom(endpoint) do
-        endpoint.static_url <> endpoint.static_path(path)
+        endpoint.static_url(path)
       end
 
       @doc """


### PR DESCRIPTION
In the Endpoint you create a function like:

```
def static_url_override(_url, path) do
  MayAppWeb.AssetHelpers.sign(path)
end
```

Note: `path` will be the digested asset path